### PR TITLE
Tested config eval sheet section and fixed bugs accordingly

### DIFF
--- a/conf/eval_test.conf
+++ b/conf/eval_test.conf
@@ -1,0 +1,17 @@
+server {
+    listen localhost:9090;
+    server_name webserver-a.org;
+    root /var/www;
+    error_page 404 /error/404.html;
+	client_max_body_size 10;
+    location / {
+    	allow_methods POST GET DELETE;
+        index html/index.html;
+    }
+
+}
+
+server {
+    listen localhost:8081;
+	client_max_body_size 10;
+}

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -28,7 +28,7 @@ server {
     error_page 402 /error/402.html;
     error_page 404 /error/404.html;
     location / {
-        index index.html;
+        index index_b.html;
     }
     location /uploads {
         allow_methods GET POST;

--- a/include/ClientHandler.hpp
+++ b/include/ClientHandler.hpp
@@ -42,7 +42,8 @@ class ClientHandler {
 		void								_handle_incoming_data();
 		void								_handle_outgoing_data();
 		std::optional<std::string> 			_retrieve_error_path(int error_code, Config &config);
-		void								_build_error_response(int status_code, const std::string& message);
+		// void								_build_error_response(int status_code, const std::string& message);
+		void								_build_error_response(int status_code, const std::string& message, std::optional<std::string> error_path);
 		void								_build_redirection_response(int status_code, const std::string& message);
 		void								_process_request();
 		void								_parse(std::vector<char>& data);

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <optional>
 
 struct Location {
 	std::string								path;
@@ -29,10 +30,17 @@ struct Config {
 	std::vector<std::string>					methods;
 	std::unordered_map<std::string, Location>	location;
 	std::string									root;
-	int											client_max_body_size;
+	int											client_max_body_size = 0;
 	std::unordered_map<int, std::string>		error_page;
 	std::vector<std::string>					paths;
 	std::string									index;
+
+	std::optional<std::string>	get_server_name(int index)
+	{
+		if (server_name.empty() || server_name[index].empty())
+			return std::nullopt;
+		return server_name[index];
+	}
 };
 
 const Config DEFAULT_CONFIG = {

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -57,13 +57,13 @@ void ConnectionManager::add_listener(Config config, int port)
 	if (_listeners.find(port) != _listeners.end())
 	{
 		listener = _listeners[port].get();
-		LOG_NOTICE("Adding config to socket for " << config.server_name[0] << " on port: " << port);
+		LOG_NOTICE("Adding config to socket for " << config.get_server_name(0).value_or("") << " on port: " << port);
 	}
 	else
 	{
 		listener = new HttpListener(port, *this);
 		_listeners[port] = std::shared_ptr<HttpListener>(listener);
-		LOG_NOTICE("Adding listener socket for " << config.server_name[0] << " on port: " << port);
+		LOG_NOTICE("Adding listener socket for " << config.get_server_name(0).value_or("") << " on port: " << port);
 	}
 	listener->add_config(config);
 }

--- a/src/FileHandler.cpp
+++ b/src/FileHandler.cpp
@@ -85,7 +85,6 @@ void FileHandler::_open_file()
 		throw HttpException(409, "Conflict");
 	}
 	_file.is_open = true;
-	// LOG_DEBUG("Opened file successfully");
 }
 
 void FileHandler::_create_file()

--- a/src/HttpObjects/HttpResponse.cpp
+++ b/src/HttpObjects/HttpResponse.cpp
@@ -44,6 +44,7 @@ void			HttpResponse::append_body(std::string &buffer)
 std::string		HttpResponse::to_string() const
 {
 	std::string response;
+
 	response += "HTTP/1.1 " + std::to_string(_status_code) + " " + _status_message + "\r\n";
 	for (auto [key, value]: _header)
 	{

--- a/tests/siege_test.sh
+++ b/tests/siege_test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 URL="http://localhost:9090"
-DURATION="10s"
+DURATION="15s"
 
 echo "Testing Siege for $DURATION"
-siege -c 200 -t $DURATION $URL &
+siege -b -t $DURATION $URL &
 SIEGE_PID=$!
 
 # Function to monitor memory usage

--- a/var/www/html/index.html
+++ b/var/www/html/index.html
@@ -18,7 +18,7 @@ body {
 	</head>
 	<body>
 		<div>
-			<h1>Welcome to our Webserver</h1>
+			<h1>Welcome to Webserver_a</h1>
 			<p>This is the default page</p>
 			<h2>Tests</h1>
 

--- a/var/www/html/index_b.html
+++ b/var/www/html/index_b.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>index.html</title>
+		<style>
+body {
+	background-color: #18191a;
+	color: #B0B3B8;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	font-size: 1.5em;
+}
+		</style>	
+	</head>
+	<body>
+		<div>
+			<h1>Welcome to Webserver-b</h1>
+			<p>This is the default page</p>
+			<h2>Tests</h1>
+
+			<ul>
+				<li><a href="/post_test.html">Upload a file</a></li>
+				<li><a href="/delete_test.html">Delete a file</a></li>
+				<li><a href="/cgi_test.html">Run a script</a></li>
+			</ul>
+
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
Fixed bug where FileHandler throws error and terminates, _retrieve_error_path now also returns nullopt if error page is in config but doesn't exist on the server, fixed segfault when no server name was given by imlementing an optional get_server_name() method in the Config